### PR TITLE
logging: allow specific LogLevels for a class in config

### DIFF
--- a/README
+++ b/README
@@ -49,10 +49,18 @@ Contents of the AfsConfig :
     - use keytab from file ...
     - pagsh; kinit  -k -t  $KRB5CCNAME; aklog ; call child..
     """
-- AFS Cellname
-- Keberos REALM
+- default AFS Cellname
+- default Keberos REALM
 - DAO-implementation to use
 - DB-implementation to use.
+- Logging. There are two types of Loglevels,
+  - the global one for all modules : 
+     e.g.  globalLogLevel="[debug|info|warn|critical]"
+  - a class local one to override the global one for certain classes.
+    CSV list of Classname=Loglevel pairs:
+    e.g. classLogLevels="CellService=warn,UbikPeerDAO=warn,FileServerDAO=debug"
+    beside the normal classes, also "util" and "sqlalchemy" are available.
+
 
 Policies :
 ========

--- a/afs/dao/BaseDAO.py
+++ b/afs/dao/BaseDAO.py
@@ -21,18 +21,18 @@ class BaseDAO(object) :
     
     def __init__(self):
         # LOG INIT
-        self.Logger=logging.getLogger("afs.dao.%s" % self.__class__.__name__)
+        LogExtra={'classname' : self.__class__.__name__}
+        Logger=logging.getLogger("afs.dao.%s" % self.__class__.__name__)
+	self.Logger=logging.LoggerAdapter(Logger,LogExtra)
         # we would like to have DAO directly useable
         # thus, just try to setup logging
         try :
-            from afs.util.AfsConfig import AfsConfig
             import afs
-            numeric_level = getattr(logging,afs.defaultConfig.LogLevel.upper() , None)
-            self.Logger.setLevel(numeric_level)
+            numeric_level = getattr(logging,afs.defaultConfig.classLogLevels[self.__class__.__name__].upper() , None)
+            Logger.setLevel(numeric_level)
+            self.Logger.debug("initializing %s-Object" % (self.__class__.__name__))
         except :
-            pass 
-    
-        self.Logger.debug("initializing %s-Object" % self.__class__.__name__)
+            pass
         
         return
         

--- a/afs/orm/DbMapper.py
+++ b/afs/orm/DbMapper.py
@@ -2,12 +2,12 @@ import sys,logging
 import afs.util.options
 from afs.util.options import define, options
 import afs.exceptions.ORMError as  ORMError
+from afs.orm import logger
 
 def setupOptions():
     """
     Only to be called from AfsConfig
     """
-    define("DB_LogLevel", default="WARN", help="Set Loglevel of DB-Logging")
     define("DB_SID" , default="db/afspy", help="Database name or for sqlite path to DB file")
     define("DB_TYPE" , default="sqlite", help="Type of DB. [mysql|sqlite]")
     # mysql options
@@ -17,6 +17,7 @@ def setupOptions():
     define("DB_PASSWD" , default="", help="Database password")
     define("DB_FLUSH", default=100, help="Max Number of elements in Buffer")
 
+    
 def createDbEngine(conf):
     """
     using conf, setup the core DB-engine
@@ -25,8 +26,6 @@ def createDbEngine(conf):
     used AfsConfig object
     """
     from sqlalchemy import create_engine
-    logger=logging.getLogger("sqlalchemy")
-    logger.setLevel(getattr(logging, conf.DB_LogLevel.upper()))
 
     # Option definition
     ###########################################
@@ -57,8 +56,6 @@ def setupDbMappers(conf):
     from sqlalchemy     import ForeignKey, UniqueConstraint
     from sqlalchemy     import  PickleType
 
-    logger=logging.getLogger("sqlalchemy")
-    logger.setLevel(getattr(logging, conf.DB_LogLevel.upper()))
     logger.debug("Entering setupDbMappers")
     metadata = MetaData()
    

--- a/afs/orm/__init__.py
+++ b/afs/orm/__init__.py
@@ -1,2 +1,16 @@
 # Init 
 __all__=["DbMapper",]
+
+# setup logging, but only when configuration is setup properly
+import afs
+import logging
+
+_logger=logging.getLogger("DBCache")
+if getattr(afs,"defaultConfig",None) :
+    if getattr(afs.defaultConfig, "classBasedLogLevels", None) :
+        classBasedLogLevel=afs.defaultConfig.classLogLevels.get("DBCache", None)
+        if classBasedLogLevel != None :
+            _logger.setLevel(getattr(logging, afs.defaultConfig.classBasedLogLevels["DBCache"].upper()))
+
+LogExtra={'classname' : "DBCache"}
+logger=logging.LoggerAdapter(_logger,LogExtra)

--- a/afs/service/BaseService.py
+++ b/afs/service/BaseService.py
@@ -20,10 +20,12 @@ class BaseService(object):
             self._CFG = afs.defaultConfig
         
         # LOG INIT
-        self.Logger=logging.getLogger("afs.%s" % self.__class__.__name__)
-        numeric_level = getattr(logging,afs.defaultConfig.LogLevel.upper() , None)
-        self.Logger.setLevel(numeric_level)
-        self.Logger.debug("initializing %s-Object with conf=%s" % (self.__class__.__name__,conf))
+        Logger=logging.getLogger("afs.service.%s" % self.__class__.__name__)
+        LogExtra={'classname' : self.__class__.__name__}
+        self.Logger=logging.LoggerAdapter(Logger,LogExtra)
+        numeric_level = getattr(logging,afs.defaultConfig.classLogLevels[self.__class__.__name__].upper() , None)
+        Logger.setLevel(numeric_level)
+        self.Logger.debug("initializing Object with conf=%s" % (conf))
         
         # DB INIT 
         if self._CFG.DB_CACHE :

--- a/afs/util/__init__.py
+++ b/afs/util/__init__.py
@@ -1,3 +1,5 @@
 # Init 
 import logging
-logger=logging.getLogger("util")
+_logger=logging.getLogger("util")
+LogExtra={'classname' : "util"}
+logger=logging.LoggerAdapter(_logger,LogExtra)

--- a/afs/util/options.py
+++ b/afs/util/options.py
@@ -362,7 +362,10 @@ class _LogFormatter(logging.Formatter):
             record.message = "Bad message (%r): %r" % (e, record.__dict__)
         record.asctime = time.strftime(
             "%y%m%d %H:%M:%S", self.converter(record.created))
-        prefix = '[%(levelname)1.1s %(asctime)s %(module)s:%(lineno)d]' % \
+        if not record.__dict__.has_key("classname") :
+	    record.__dict__["classname"] = ""
+
+        prefix = '[%(levelname)1.1s %(asctime)s %(classname)s %(module)s:%(lineno)d]' % \
             record.__dict__
         if self._color:
             prefix = (self._colors.get(record.levelno, self._normal) +

--- a/tests/afspy.cfg
+++ b/tests/afspy.cfg
@@ -7,5 +7,5 @@ DB_SID="afspy_test"
 DB_HOST="localhost"
 DB_PORT=3306
 DB_USER="hanke"
-DB_LogLevel="warn"
-LogLevel="debug"
+globalLogLevel="debug"
+classLogLevels="CellService=debug,UbikPeerDAO=warn,FileServerDAO=debug,sqlalchemy=debug"


### PR DESCRIPTION
have now 2 options for LogLevel:
globalLogLevel and classLogLevels,
where classLogLevels is CSV list of
Classname=Loglevel pairs:
e.g.
classLogLevels="CellService=warn,UbikPeerDAO=info,sqlalchemy=info"
