### PR TITLE
orm: fix Mapping. again.

### DIFF
--- a/afs/model/Partition.py
+++ b/afs/model/Partition.py
@@ -30,4 +30,4 @@ class Partition(BaseModel):
         self.cdate   = datetime.now()
         self.udate   = datetime.now()
         self.sync    = 0
-        self._isComplete = False
+        self.isComplete = False

--- a/afs/model/Server.py
+++ b/afs/model/Server.py
@@ -46,4 +46,4 @@ class Server(BaseModel):
         ## flag if this object is synced with reality.
         self.sync    = 0
         ## flag if this object is not fully filled yet
-        self._isComplete = False
+        self.isComplete = False

--- a/afs/model/Token.py
+++ b/afs/model/Token.py
@@ -11,5 +11,5 @@ class Token(object):
         initialize an empty object
         """
         #Check the cell
-        self._CELL_NAME = cellname
-        self._AFS_ID = afsid
+        self.CELL_NAME = cellname
+        self.AFS_ID = afsid

--- a/afs/orm/DbMapper.py
+++ b/afs/orm/DbMapper.py
@@ -101,6 +101,7 @@ def setupDbMappers(conf):
           Column('cdate'        , DateTime),
           Column('udate'        , DateTime),
           Column('sync'         , Integer ),
+          Column('isComplete'   , Boolean ),
           sqlite_autoincrement=True
           )
     #Mapping Table
@@ -124,6 +125,7 @@ def setupDbMappers(conf):
           Column('cdate'        , DateTime),
           Column('udate'        , DateTime),
           Column('sync'         , Integer ),
+          Column('isComplete'   , Boolean ),
           sqlite_autoincrement=True
           ) 
     #Mapping Table


### PR DESCRIPTION
in the present SafeMapper, we cannot use DB-fields
with a preceding _.
