### PR TITLE
cmd-line parsing: hide advanced options.

### DIFF
--- a/afs/__init__.py
+++ b/afs/__init__.py
@@ -18,15 +18,15 @@ util_argParser=util.setupOptions()
 model_argParser=model.setupOptions()
 
 global argParser
-argParser=argparse.ArgumentParser(parents=[orm_argParser, dao_argParser, service_argParser, util_argParser,model_argParser])
+argParser=argparse.ArgumentParser(parents=[orm_argParser, dao_argParser, service_argParser, util_argParser,model_argParser],epilog="For more options, see documentation and example config-files")
 
 argParser.add_argument("--config","-c" ,  default="", help="path to configuration file" )
-argParser.add_argument("--DAOImplementation", default="", help="Implementation of how to access AFS-Cell" )
-argParser.add_argument("--DAO_SPOOL_PARENTDIR", default="", help="If using 'childprocs'-DAO,  use spool dir under this path")
-argParser.add_argument("--globalLogLevel", default="", help="global python Loglevel")
 argParser.add_argument("--CELL_NAME", default="", help="Default Cell")
-argParser.add_argument("--ignoreIP",  default=[],action="append",  help="IP to ignore for active polling. May be used more than once. Useful for multi-homed servers and complex network-topologies")
-argParser.add_argument("--hostmap",  default=[],action="append",  help="hostname,IP-pairs to override complex DNS-setups with aliases.")
+argParser.add_argument("--globalLogLevel", default="", help=argparse.SUPPRESS)
+argParser.add_argument("--DAOImplementation", default="", help=argparse.SUPPRESS )
+argParser.add_argument("--DAO_SPOOL_PARENTDIR", default="", help=argparse.SUPPRESS)
+argParser.add_argument("--ignoreIP",  default=[],action="append",  help=argparse.SUPPRESS)
+argParser.add_argument("--hostmap",  default=[],action="append",  help=argparse.SUPPRESS)
 
 # a Namespace Object to be created from argParser
 global defaultConfig

--- a/afs/dao/__init__.py
+++ b/afs/dao/__init__.py
@@ -2,9 +2,13 @@
 __all__=["BNodeDAO","CacheManagerDAO","FileServerDAO","FileSystemDAO","OsdDbDAO","PTDbDAO","RxDAO","RxOsdDAO","RXPeerDAO","UbikPeerDAO","VLDbDAO","VolumeDAO","OSDVolumeDAO","OSDFileServerDAO"]
 
 def setupOptions():   
-        import argparse
-        argParser=argparse.ArgumentParser(add_help=False)
-        argParser.add_argument("--LogLevel_DAO", default="", help="loglevel fo all daos")
-        for d in __all__ :
-            argParser.add_argument("--LogLevel_%s" %d , default="", help="loglevel of class %s" % (d))
-        return argParser
+    """
+    add logging options to cmd-line,
+    but surpress them, so that they don't clobber up the help-messages
+    """
+    import argparse
+    argParser=argparse.ArgumentParser(add_help=False)
+    argParser.add_argument("--LogLevel_DAO", default="", help=argparse.SUPPRESS)
+    for d in __all__ :
+        argParser.add_argument("--LogLevel_%s" %d , default="", help=argparse.SUPPRESS)
+    return argParser

--- a/afs/etc/afspy.cfg
+++ b/afs/etc/afspy.cfg
@@ -1,12 +1,85 @@
+#
+# afspy configuration file.
+#
+
+#
+# All options mentionend here
+# can be overridden on the commandline
+# using exactly the same options-name, prefixed by "--".
+#
+
+
+# general 
 CELL_NAME=ipp-garching.mpg.de
-KRB5_REALM=IPP-GARCHING.MPG.DE
+
+# database options
 DB_CACHE=true
 DB_TYPE=mysql
 DB_SID=afspy
 DB_HOST=localhost
 DB_PORT=3306
 DB_USER=afspy
-globalLogLevel=warn
+
+# dns and networking 
+# ip-addresses published by servers to ignore.
+# may be given more than once
 ignoreIP=
+
+#
+# hostnames to use for given IP-addresses.
+# useful for silly hostaliases.
 hostmap=afs-hgw1.ipp-hgw.mpg.de=194.94.214.4
 hostmap=afs-db-hgw.ipp-hgw.mpg.de=194.94.214.140
+
+
+#
+# DAO 
+
+# how afs-coomands should be executed.
+# possible values : childprocs, detached
+DAOImplementation=
+
+# when executing DAOs in detached mode, 
+# you must specify where the results are stored
+DAO_SPOOL_PARENTDIR=
+
+#
+# logging
+# the argument must be one of the standard python loglevels.
+globalLogLevel=warn
+
+#
+# detailed logging
+# if you want to debug, you can set the LogLevel of a 
+# specific module.
+# available options are:
+
+# loglevel for all DAOs:
+# LogLevel_DAO=warn
+# loglevel for a specific DAO, %s=classname of DAO, e.g. LogLeveL=UbikPeerDAO
+# LogLevel_%s
+
+# loglevel for Model-class operations
+# LogLevel_Model
+
+# loglevel for sqlalchemy
+# LogLevel_sqlalchemy
+
+# loglevel for DBCache-operations
+# LogLevel_DB_CACHE
+
+# loglevel for all services
+# LogLevel_Service
+
+# loglevel for a specific service, %s=classname of service, e.g. LogLeveL=LogLevel_FsService
+# LogLevel_%s
+
+# loglevel for methods in util
+# LogLevel_util
+
+# loglevel for lookup cache
+# LogLevel_LookupUtil
+
+# loglevel for setting up  orm
+# LogLevel_DBManager
+

--- a/afs/model/__init__.py
+++ b/afs/model/__init__.py
@@ -1,8 +1,12 @@
 # Init 
 __all__=["BaseModel","BNode","Bos","Cell","Partition","PTDb","QueryCache","Server","Token","VLDb","VolumeExtra","VolumeGroup","VolumeOSD","Volume",]
 
-def setupOptions():   
-        import argparse
-        argParser=argparse.ArgumentParser(add_help=False)
-        argParser.add_argument("--LogLevel_Model", default="", help="loglevel of model object manipulations" )
-        return argParser
+def setupOptions():       
+    """
+    add logging options to cmd-line,
+    but surpress them, so that they don't clobber up the help-messages
+    """
+    import argparse
+    argParser=argparse.ArgumentParser(add_help=False)
+    argParser.add_argument("--LogLevel_Model", default="", help=argparse.SUPPRESS )
+    return argParser

--- a/afs/orm/__init__.py
+++ b/afs/orm/__init__.py
@@ -2,21 +2,25 @@
 __all__=["DbMapper",]
 
 def setupOptions():   
+    """
+    add logging options to cmd-line,
+    but surpress them, so that they don't clobber up the help-messages
+    """
     import argparse
     argParser=argparse.ArgumentParser(add_help=False)
     # setup DB_CACHE options
-    argParser.add_argument("--DB_CACHE",  default="", help="use DB cache")
-    argParser.add_argument("--DB_SID" , default="", help="Database name or for sqlite path to DB file")
-    argParser.add_argument("--DB_TYPE" , default="", help="Type of DB. [mysql|sqlite]")
+    argParser.add_argument("--DB_CACHE",  default="", help=argparse.SUPPRESS)
+    argParser.add_argument("--DB_SID" , default="", help=argparse.SUPPRESS)
+    argParser.add_argument("--DB_TYPE" , default="", help=argparse.SUPPRESS)
     # mysql options
-    argParser.add_argument("--DB_HOST", default="", help="Database host")
-    argParser.add_argument("--DB_PORT", default="", help="Database port")
-    argParser.add_argument("--DB_USER", default="", help="Database user")
-    argParser.add_argument("--DB_PASSWD" , default="", help="Database password")
-    argParser.add_argument("--DB_FLUSH", default="", help="Max Number of elements in Buffer")
-    # for logging sqlalchmy
-    argParser.add_argument("--LogLevel_sqlalchemy", default="", help="loglevel of module sqlalchemy")
-    argParser.add_argument("--LogLevel_DB_CACHE", default="", help="loglevel of DB_CACHE")
+    argParser.add_argument("--DB_HOST", default="", help=argparse.SUPPRESS)
+    argParser.add_argument("--DB_PORT", default="", help=argparse.SUPPRESS)
+    argParser.add_argument("--DB_USER", default="", help=argparse.SUPPRESS)
+    argParser.add_argument("--DB_PASSWD" , default="", help=argparse.SUPPRESS)
+    argParser.add_argument("--DB_FLUSH", default="", help=argparse.SUPPRESS)
+    # for logging, but don't show up in --help
+    argParser.add_argument("--LogLevel_sqlalchemy", default="", help=argparse.SUPPRESS)
+    argParser.add_argument("--LogLevel_DB_CACHE", default="", help=argparse.SUPPRESS)
     return argParser
 
 

--- a/afs/service/__init__.py
+++ b/afs/service/__init__.py
@@ -2,9 +2,13 @@
 __all__=["AuthService","BaseService","CellService","FsService","PtService","ProjectService","QueryVol","VolService","OSDVolService","OSDFsService","OSDCellService","DBsService","BsService"]
 
 def setupOptions():   
-        import argparse
-        argParser=argparse.ArgumentParser(add_help=False)
-        argParser.add_argument("--LogLevel_Service", default="", help="loglevel fo all serivces")
-        for d in __all__ :
-            argParser.add_argument("--LogLevel_%s" %d , default="", help="loglevel of class %s" % (d))
-        return argParser
+    """
+    add logging options to cmd-line,
+    but surpress them, so that they don't clobber up the help-messages
+    """
+    import argparse
+    argParser=argparse.ArgumentParser(add_help=False)
+    argParser.add_argument("--LogLevel_Service", default="", help=argparse.SUPPRESS)
+    for d in __all__ :
+        argParser.add_argument("--LogLevel_%s" %d , default="", help=argparse.SUPPRESS)
+    return argParser

--- a/afs/tests/BaseTest.py
+++ b/afs/tests/BaseTest.py
@@ -38,7 +38,7 @@ class TestDataBaseTearDown :
         return
 
 def parseCMDLine():
-    myParser=argparse.ArgumentParser(parents=[afs.argParser], add_help=False)
+    myParser=argparse.ArgumentParser(parents=[afs.argParser], add_help=False,epilog=afs.argParser.epilog)
     myParser.add_argument("--setup", default="./Test.cfg", help="path to Testconfig")
     parseDefaultConfig(myParser)
     if not os.path.exists(afs.defaultConfig.setup) :

--- a/afs/util/__init__.py
+++ b/afs/util/__init__.py
@@ -1,8 +1,12 @@
 # Init 
 
 def setupOptions():   
-        import argparse
-        argParser=argparse.ArgumentParser(add_help=False)
-        for d in ["util","DBManager"]:
-            argParser.add_argument("--LogLevel_%s" %d , default="", help="loglevel of class %s" % (d))
-        return argParser
+    """
+    add logging options to cmd-line,
+    but surpress them, so that they don't clobber up the help-messages
+    """
+    import argparse
+    argParser=argparse.ArgumentParser(add_help=False)
+    for d in ["util","DBManager"]:
+        argParser.add_argument("--LogLevel_%s" %d , default="", help=argparse.SUPPRESS)
+    return argParser


### PR DESCRIPTION
but explain them in the config file instead.
afspy applications should use the epilog of the parent argparse object.
tests now do that.
