### PR TITLE
dao: fix execwrapper decorator

### DIFF
--- a/afs/dao/BNodeDAO_parse.py
+++ b/afs/dao/BNodeDAO_parse.py
@@ -34,7 +34,7 @@ def minutes2restartT(Minutes) :
     Time = "%d:%02d %s" % (Minutes/60, Minutes%60,Pod)
     return Time
 
-def getRestartTimes(rc,output,outerr,execParamList,Logger):
+def getRestartTimes(rc,output,outerr,parseParamList,Logger):
     if rc :
         raise BNodeError( outerr, output)
     
@@ -46,7 +46,7 @@ def getRestartTimes(rc,output,outerr,execParamList,Logger):
     st["binary"]=binaryRestartRegEX.match(output[1]).groups()[1].strip()
     return st
 
-def getDBServList(rc,output,outerr,execParamList,Logger) :
+def getDBServList(rc,output,outerr,parseParamList,Logger) :
     if rc :
        raise BNodeError(outerr, output)
     DBServers=[]
@@ -65,77 +65,77 @@ def getDBServList(rc,output,outerr,execParamList,Logger) :
     return DBServers
 
 
-def status(rc,output,outerr,execParamList,Logger):
+def status(rc,output,outerr,parseParamList,Logger):
     if rc :
         raise BNodeError( outerr, output)
     return
 
-def salvage(rc,output,outerr,execParamList,Logger):
+def salvage(rc,output,outerr,parseParamList,Logger):
     if rc :
         raise BNodeError( outerr, output)
     return
 
-def runStop(rc,output,outerr,execParamList,Logger):
+def runStop(rc,output,outerr,parseParamList,Logger):
     if rc :
         raise BNodeError( outerr, output)
     return
 
-def setRestartTimes(rc,output,outerr,execParamList,Logger):
+def setRestartTimes(rc,output,outerr,parseParamList,Logger):
     if rc :
         raise BNodeError( outerr, output)
     return
 
-def addUser(rc,output,outerr,execParamList,Logger):
+def addUser(rc,output,outerr,parseParamList,Logger):
     if rc :
         raise BNodeError( outerr, output)
     return
 
-def removeUser(rc,output,outerr,execParamList,Logger):
+def removeUser(rc,output,outerr,parseParamList,Logger):
     if rc :
         raise BNodeError( outerr, output)
     return
 
-def getUserList(rc,output,outerr,execParamList,Logger):
+def getUserList(rc,output,outerr,parseParamList,Logger):
     if rc :
         raise BNodeError( outerr, output)
     return
 
-def getFileDate(rc,output,outerr,execParamList,Logger):
+def getFileDate(rc,output,outerr,parseParamList,Logger):
     if rc :
         raise BNodeError( outerr, output)
     return
 
-def cmd(rc,output,outerr,execParamList,Logger):
+def cmd(rc,output,outerr,parseParamList,Logger):
     if rc :
         raise BNodeError( outerr, output)
     return
 
-def getLog(rc,output,outerr,execParamList,Logger):
+def getLog(rc,output,outerr,parseParamList,Logger):
     if rc :
         raise BNodeError( outerr, output)
     return
 
-def pruneLog(rc,output,outerr,execParamList,Logger):
+def pruneLog(rc,output,outerr,parseParamList,Logger):
     if rc :
         raise BNodeError( outerr, output)
     return
 
-def runRestart(rc,output,outerr,execParamList,Logger):
+def runRestart(rc,output,outerr,parseParamList,Logger):
     if rc :
         raise BNodeError( outerr, output)
     return
 
-def runStart(rc,output,outerr,execParamList,Logger):
+def runStart(rc,output,outerr,parseParamList,Logger):
     if rc :
         raise BNodeError( outerr, output)
     return
 
-def runShutdown(rc,output,outerr,execParamList,Logger):
+def runShutdown(rc,output,outerr,parseParamList,Logger):
     if rc :
         raise BNodeError( outerr, output)
     return
 
-def runStartup(rc,output,outerr,execParamList,Logger):
+def runStartup(rc,output,outerr,parseParamList,Logger):
     if rc :
         raise BNodeError( outerr, output)
     return

--- a/afs/dao/CacheManagerDAO_parse.py
+++ b/afs/dao/CacheManagerDAO_parse.py
@@ -1,11 +1,11 @@
 from afs.exceptions.CMError import CMError
 
-def parse_newCellAlias(rc,output,outerr,execParamList,Logger) :
+def parse_newCellAlias(rc,output,outerr,parseParamList,Logger) :
     if rc :
         raise CMError("error: %s" % outerr)
     return
 
-def parse_getWsCell(rc,output,outerr,execParamList,Logger) :
+def parse_getWsCell(rc,output,outerr,parseParamList,Logger) :
     if rc :
         raise CMError("error: %s" % outerr)
 
@@ -15,28 +15,28 @@ def parse_getWsCell(rc,output,outerr,execParamList,Logger) :
     return cellname
 
 
-def parse_flushall(rc,output,outerr,execParamList,Logger) :
+def parse_flushall(rc,output,outerr,parseParamList,Logger) :
     if rc :
         raise CMError("error: %s" % outerr)
     return
 
-def parse_flushvolume(rc,output,outerr,execParamList,Logger) :
+def parse_flushvolume(rc,output,outerr,parseParamList,Logger) :
     if rc :
         raise CMError("error: %s" % outerr)
     return
 
-def parse_flushmount(rc,output,outerr,execParamList,Logger) :
+def parse_flushmount(rc,output,outerr,parseParamList,Logger) :
     if rc :
         raise CMError("error: %s" % outerr)
     return
 
-def parse_flush(rc,output,outerr,execParamList,Logger) :
+def parse_flush(rc,output,outerr,parseParamList,Logger) :
     if rc :
         raise CMError("error: %s" % outerr)
     return
 
 
-def parse_getCellAliases(rc,output,outerr,execParamList,Logger) :
+def parse_getCellAliases(rc,output,outerr,parseParamList,Logger) :
     if rc :
         raise CMError("error: %s" % outerr)
     return

--- a/afs/dao/DNSconfDAO_parse.py
+++ b/afs/dao/DNSconfDAO_parse.py
@@ -1,6 +1,6 @@
 from afs.exceptions.AfsError import AfsError
 
-def getDBServList(rc,output,outerr,execParamList,Logger) :
+def getDBServList(rc,output,outerr,parseParamList,Logger) :
     if rc :
         raise AfsError
     # parse "This workstation belongs to cell 'beolink.org'"

--- a/afs/dao/FileServerDAO_parse.py
+++ b/afs/dao/FileServerDAO_parse.py
@@ -3,7 +3,7 @@ from afs.exceptions.FServError import FServError
 from afs.util import afsutil
 
 
-def getVolList(rc, output, outerr, execParamList, Logger) :
+def getVolList(rc, output, outerr, parseParamList, Logger) :
     if rc :
         raise FServError("Error",outerr)
         
@@ -118,7 +118,7 @@ def getVolList(rc, output, outerr, execParamList, Logger) :
                 volList.append(vol)
     return volList
 
-def getIdVolList(rc,output,outerr,execParamList,Logger) :
+def getIdVolList(rc,output,outerr,parseParamList,Logger) :
     if rc : 
          raise FServError("Error", outerr) 
     RX=re.compile("^(\d+)")
@@ -131,7 +131,7 @@ def getIdVolList(rc,output,outerr,execParamList,Logger) :
     return volIds
 
 
-def getPartList(rc,output,outerr,execParamList,Logger) :
+def getPartList(rc,output,outerr,parseParamList,Logger) :
     if rc :
          raise FServError("Error", outerr)
     RX=re.compile("Free space on partition /vicep(\S+): (\d+) K blocks out of total (\d+)")

--- a/afs/dao/FileSystemDAO_parse.py
+++ b/afs/dao/FileSystemDAO_parse.py
@@ -1,39 +1,39 @@
 from afs.exceptions.FSError import FSError
 
-def makeMountpoint(rc,output,outerr,execParamList,Logger):
+def makeMountpoint(rc,output,outerr,parseParamList,Logger):
     return
         
-def removeMountpoint(rc,output,outerr,execParamList,Logger):
+def removeMountpoint(rc,output,outerr,parseParamList,Logger):
     return
     
-def listMountpoint(rc,output,outerr,execParamList,Logger):
+def listMountpoint(rc,output,outerr,parseParamList,Logger):
     """
     Return target volume of a mount point
     """
     mountpoint=""
     return mountpoint
     
-def getCellByPath(rc,output,outerr,execParamList,Logger):
+def getCellByPath(rc,output,outerr,parseParamList,Logger):
     """
     Returns the cell to which a file or directory belongs
     """
     cellname=""
     return cellname
     
-def setQuota(rc,output,outerr,execParamList,Logger):
+def setQuota(rc,output,outerr,parseParamList,Logger):
     """
     Set a volume-quota by path
     """
     return
     
-def listQuota(rc,output,outerr,execParamList,Logger):
+def listQuota(rc,output,outerr,parseParamList,Logger):
     """
     list a volume quota by path
     """
     quota=-1
     return quota
 
-def returnVolumeByPath(rc,output,outerr,execParamList,Logger):
+def returnVolumeByPath(rc,output,outerr,parseParamList,Logger):
     """
     Basically a fs examine
     """

--- a/afs/dao/OSDFileServerDAO_parse.py
+++ b/afs/dao/OSDFileServerDAO_parse.py
@@ -2,7 +2,7 @@ import re, datetime
 from afs.util import afsutil
 from afs.exceptions.FServError import FServError
 
-def getVolList(rc,output,outerr,execParamList,Logger) :
+def getVolList(rc,output,outerr,parseParamList,Logger) :
     if rc :
         raise FServError("Error",outerr)
     # first line gives Name, ID, Type, Used and Status 
@@ -142,7 +142,7 @@ def getVolList(rc,output,outerr,execParamList,Logger) :
                 volList.append(vol)
     return volList
 
-def getIdVolList(rc,output,outerr,execParamList,Logger):
+def getIdVolList(rc,output,outerr,parseParamList,Logger):
     RX=re.compile("^(\d+)")
     volIds = []
     for line in output [1:]:

--- a/afs/dao/OSDVolumeDAO_parse.py
+++ b/afs/dao/OSDVolumeDAO_parse.py
@@ -3,12 +3,12 @@ from datetime import datetime
 from afs.exceptions.VolError import VolError
 from afs.util import afsutil
 
-def create(rc,output,outerr,execParamList,Logger) :
+def create(rc,output,outerr,parseParamList,Logger) :
     if rc:
         raise VolError("Error", outerr)
     return
 
-def getVolGroupList(rc,output,outerr,execParamList,Logger) :
+def getVolGroupList(rc,output,outerr,parseParamList,Logger) :
     if rc:
         raise VolError("Error", outerr)
 
@@ -53,11 +53,11 @@ def getVolGroupList(rc,output,outerr,execParamList,Logger) :
             break
     return volGroup
        
-def getVolume(rc,output,outerr,execParamList,Logger) : 
+def getVolume(rc,output,outerr,parseParamList,Logger) : 
        
-        name_or_id=execParamList["args"][0] 
-        serv=execParamList["args"][1] 
-        part=execParamList["args"][2] 
+        name_or_id=parseParamList["args"][0] 
+        serv=parseParamList["args"][1] 
+        part=parseParamList["args"][2] 
         line_no = 0
         line = output[line_no]
        
@@ -144,7 +144,7 @@ def getVolume(rc,output,outerr,execParamList,Logger) :
             vol = None
         return vol
 
-def traverse(rc,output,outerr,execParamList,Logger) :
+def traverse(rc,output,outerr,parseParamList,Logger) :
     if rc or "AFSVolTraverse failed" in string.join(outerr) :
         raise VolError("Cannot traverse volume: %s" % outerr)
     histogram={}

--- a/afs/dao/OsdDbDAO_parse.py
+++ b/afs/dao/OsdDbDAO_parse.py
@@ -1,7 +1,7 @@
 import re,string,os,sys
 from afs.exceptions.OsdDbError import OsdDbError
 
-def getStatistics(rc,output,outerr,execParamList,Logger) :
+def getStatistics(rc,output,outerr,parseParamList,Logger) :
     if rc:
         raise OsdDbError("Error", outerr)
 

--- a/afs/dao/RXPeerDAO_parse.py
+++ b/afs/dao/RXPeerDAO_parse.py
@@ -1,6 +1,6 @@
 import re
 
-def parse_getVersionandBuildDate(rc,output,outerr,execParamList,Logger):
+def parse_getVersionandBuildDate(rc,output,outerr,parseParamList,Logger):
     RXVerRegEx=re.compile("AFS version:  OpenAFS(.*)built (.*)")
     if len(output) != 2 :
         version="Not readable."

--- a/afs/dao/RxOsdDAO_parse.py
+++ b/afs/dao/RxOsdDAO_parse.py
@@ -2,52 +2,52 @@ import re,string,os,sys
 from afs.exceptions.RxOsdError import RxOsdError
 
 
-def parse_examine(rc,output,outerr,execParamList,Logger):
+def parse_examine(rc,output,outerr,parseParamList,Logger):
     if rc:
         raise RxOsdError("Error", outerr)
     return
 
-def parse_getFetchQueue(rc,output,outerr,execParamList,Logger):
+def parse_getFetchQueue(rc,output,outerr,parseParamList,Logger):
     if rc:
         raise RxOsdError("Error", outerr)
     return
 
-def parse_getListOfServerSettings(rc,output,outerr,execParamList,Logger):
+def parse_getListOfServerSettings(rc,output,outerr,parseParamList,Logger):
     if rc:
         raise RxOsdError("Error", outerr)
     return
 
-def parse_getServerSetting(rc,output,outerr,execParamList,Logger):
+def parse_getServerSetting(rc,output,outerr,parseParamList,Logger):
     if rc:
         raise RxOsdError("Error", outerr)
     return
 
-def parse_setServerSetting(rc,output,outerr,execParamList,Logger):
+def parse_setServerSetting(rc,output,outerr,parseParamList,Logger):
     if rc:
         raise RxOsdError("Error", outerr)
     return
 
-def parse_getObjectsofVolumeByOsd(rc,output,outerr,execParamList,Logger):
+def parse_getObjectsofVolumeByOsd(rc,output,outerr,parseParamList,Logger):
     if rc:
         raise RxOsdError("Error", outerr)
     return
 
-def parse_getStatistics(rc,output,outerr,execParamList,Logger):
+def parse_getStatistics(rc,output,outerr,parseParamList,Logger):
     if rc:
         raise RxOsdError("Error", outerr)
     return
 
-def parse_resetStatistics(rc,output,outerr,execParamList,Logger):
+def parse_resetStatistics(rc,output,outerr,parseParamList,Logger):
     if rc:
         raise RxOsdError("Error", outerr)
     return
 
-def parse_getActiveThreads(rc,output,outerr,execParamList,Logger):
+def parse_getActiveThreads(rc,output,outerr,parseParamList,Logger):
     if rc:
         raise RxOsdError("Error", outerr)
     return
 
-def parse_getWipeCandidates(rc,output,outerr,execParamList,Logger):
+def parse_getWipeCandidates(rc,output,outerr,parseParamList,Logger):
     if rc:
         raise RxOsdError("Error", outerr)
     return

--- a/afs/dao/UbikPeerDAO_parse.py
+++ b/afs/dao/UbikPeerDAO_parse.py
@@ -16,7 +16,7 @@ HostTimeRX=re.compile("Host's (.*) time is (.*)")
 LocalTimeRX=re.compile("Local time is (.*) \(time differential (\d+) secs\)")
 LastYesVoteRX=re.compile("Last yes vote for (.*) was (.*) secs ago \(sync site\);")
     
-def parse_getShortInfo(rc, output, outerr, execParamList, Logger) :
+def parse_getShortInfo(rc, output, outerr, parseParamList, Logger) :
     """
     parse output of udebug
     """
@@ -84,7 +84,7 @@ def parse_getShortInfo(rc, output, outerr, execParamList, Logger) :
     return resDict
         
 
-def parse_getLongInfo( rc, output, outerr, execParamList,Logger) :
+def parse_getLongInfo( rc, output, outerr, parseParamList,Logger) :
     """
     Parsing is always the same, so do it here.
     """

--- a/afs/dao/VLDbDAO.py
+++ b/afs/dao/VLDbDAO.py
@@ -14,11 +14,11 @@ class VLDbDAO(BaseDAO) :
         return
     
     @execwrapper
-    def getFsServList(self,_cfg=None, noresolve=False):
+    def getFsServList(self, cellname, noresolve=False, _cfg=None):
         """
         get list of dicts of all fileservers registered in the VLDB
         """
-        CmdList=[_cfg.binaries["vos"],"listaddrs", "-printuuid", "-cell","%s" % _cfg.CELL_NAME ]
+        CmdList=[_cfg.binaries["vos"],"listaddrs", "-printuuid", "-cell","%s" % cellname]
         if noresolve :
             CmdList.append("-noresolve")
         return CmdList,PM.getFsServList
@@ -30,7 +30,7 @@ class VLDbDAO(BaseDAO) :
         return CmdList,PM.getFsUUID
 
     @execwrapper
-    def getVolumeList(self, name_or_ip, _cfg, part="", noresolve=False) :
+    def getVolumeList(self, name_or_ip, part="", noresolve=False, _cfg=None) :
         """
         Return list of volumes on a server
         """

--- a/afs/dao/VLDbDAO_parse.py
+++ b/afs/dao/VLDbDAO_parse.py
@@ -1,8 +1,8 @@
 from afs.exceptions.VLDbError import VLDbError
 from afs.util import afsutil
 
-def getFsServList(rc,output,outerr,execParamList,Logger):
-    noresolve=execParamList["kwargs"]["noresolv"]
+def getFsServList(rc,output,outerr,parseParamList,Logger):
+    noresolve=parseParamList["kwargs"]["noresolve"]
     if rc :
         raise VLDbError("Error: %s " %  outerr)
     servers = []
@@ -22,14 +22,14 @@ def getFsServList(rc,output,outerr,execParamList,Logger):
         i += 1
     return servers
 
-def getFsUUID(rc,output,outerr,execParamList,Logger) :
+def getFsUUID(rc,output,outerr,parseParamList,Logger) :
     if rc :
         raise VLDbError("Error: %s " %  outerr)
     uuid=output[0].split()[1]
     return uuid
 
-def Volumelist(rc,output,outerr,execParamList,Logger) :
-    noresolve=execParamList["kwargs"]["noresolv"]
+def Volumelist(rc,output,outerr,parseParamList,Logger) :
+    noresolve=parseParamList["kwargs"]["noresolve"]
     if rc :
         raise VLDbError("Error: %s " %  outerr)
     Volumes=[]
@@ -73,42 +73,42 @@ def Volumelist(rc,output,outerr,execParamList,Logger) :
     Logger.debug("getVolumeList: returning %s" % Volumes[:10])     
     return Volumes 
 
-def unlock(rc,output,outerr,execParamList,Logger) :
+def unlock(rc,output,outerr,parseParamList,Logger) :
     if rc :
         raise VLDbError("Error: %s " %  outerr)
     raise VLDbError("Not Implemented.")
 
-def lock(rc,output,outerr,execParamList,Logger) :
+def lock(rc,output,outerr,parseParamList,Logger) :
     if rc :
         raise VLDbError("Error: %s " %  outerr)
     raise VLDbError("Not Implemented.")
 
-def getVolumeList(rc,output,outerr,execParamList,Logger) :
+def getVolumeList(rc,output,outerr,parseParamList,Logger) :
     if rc :
         raise VLDbError("Error: %s " %  outerr)
     raise VLDbError("Not Implemented.")
 
-def syncVLDB(rc,output,outerr,execParamList,Logger) :
+def syncVLDB(rc,output,outerr,parseParamList,Logger) :
     if rc :
         raise VLDbError("Error: %s " %  outerr)
     raise VLDbError("Not Implemented.")
 
-def setaddrs(rc,output,outerr,execParamList,Logger) :
+def setaddrs(rc,output,outerr,parseParamList,Logger) :
     if rc :
         raise VLDbError("Error: %s " %  outerr)
     raise VLDbError("Not Implemented.")
 
-def addsite(rc,output,outerr,execParamList,Logger) :
+def addsite(rc,output,outerr,parseParamList,Logger) :
     if rc :
         raise VLDbError("Error: %s " %  outerr)
     raise VLDbError("Not Implemented.")
 
-def remsite(rc,output,outerr,execParamList,Logger) :
+def remsite(rc,output,outerr,parseParamList,Logger) :
     if rc :
         raise VLDbError("Error: %s " %  outerr)
     raise VLDbError("Not Implemented.")
 
-def syncServ(rc,output,outerr,execParamList,Logger) :
+def syncServ(rc,output,outerr,parseParamList,Logger) :
     if rc :
         raise VLDbError("Error: %s " %  outerr)
     raise VLDbError("Not Implemented.")

--- a/afs/dao/VolumeDAO_parse.py
+++ b/afs/dao/VolumeDAO_parse.py
@@ -3,12 +3,12 @@ from afs.util import afsutil
 from datetime import datetime
 from afs.exceptions.VolError import VolError
 
-def move(rc,output,outerr,execParamList,Logger) :
+def move(rc,output,outerr,parseParamList,Logger) :
     if rc:
         raise VolError("Error", outerr)
     return
 
-def getVolIDList(rc,output,outerr,execParamList,Logger) :
+def getVolIDList(rc,output,outerr,parseParamList,Logger) :
     if rc:
         raise VolError("Error", outerr)
     res=[]
@@ -19,7 +19,7 @@ def getVolIDList(rc,output,outerr,execParamList,Logger) :
     return res
 
 
-def getVolGroupList(rc,output,outerr,execParamList,Logger) :
+def getVolGroupList(rc,output,outerr,parseParamList,Logger) :
     if rc:
         raise VolError("Error", outerr)
 
@@ -69,12 +69,12 @@ def getVolGroupList(rc,output,outerr,execParamList,Logger) :
             break
     return volGroup
 
-def getVolume(rc,output,outerr,execParamList,Logger):
+def getVolume(rc,output,outerr,parseParamList,Logger):
     if rc:
         raise VolError("Error", outerr)
-    name_or_id=execParamList["args"]["name_or_id"]
-    serv=execParamList["args"]["serv"]
-    part=execParamList["args"]["part"]
+    name_or_id=parseParamList["args"]["name_or_id"]
+    serv=parseParamList["args"]["serv"]
+    part=parseParamList["args"]["part"]
 
     line_no = 0
     line = output[line_no]
@@ -165,30 +165,30 @@ def getVolume(rc,output,outerr,execParamList,Logger):
     return vol
 
 
-def release(rc,output,outerr,execParamList,Logger):
+def release(rc,output,outerr,parseParamList,Logger):
     if rc:
         raise VolError("Error", outerr)
 
-def setBlockQuota(rc,output,outerr,execParamList,Logger):
+def setBlockQuota(rc,output,outerr,parseParamList,Logger):
     if rc:
         raise VolError("Error", outerr)
 
-def dump(rc,output,outerr,execParamList,Logger):
+def dump(rc,output,outerr,parseParamList,Logger):
     if rc:
         raise VolError("Error", outerr)
 
-def restore(rc,output,outerr,execParamList,Logger):
+def restore(rc,output,outerr,parseParamList,Logger):
     if rc:
         raise VolError("Error", outerr)
 
-def convert(rc,output,outerr,execParamList,Logger):
+def convert(rc,output,outerr,parseParamList,Logger):
     if rc:
         raise VolError("Error", outerr)
 
-def create(rc,output,outerr,execParamList,Logger):
+def create(rc,output,outerr,parseParamList,Logger):
     if rc:
         raise VolError("Error", outerr)
 
-def remove(rc,output,outerr,execParamList,Logger):
+def remove(rc,output,outerr,parseParamList,Logger):
     if rc:
         raise VolError("Error", outerr)


### PR DESCRIPTION
to get correct parameterlist of the execution-method
including all optional parameters.
Rename parameter list to parseParamList
fix typo
